### PR TITLE
audioreach-engine: fix comment formatting

### DIFF
--- a/fwk/api/ar_utils/ar_guids.h
+++ b/fwk/api/ar_utils/ar_guids.h
@@ -22,7 +22,7 @@
 /** @addtogroup spf_utils_guids
 @{ */
 
- * GUID owner is Qualcomm.
+/** GUID owner is Qualcomm.*/
 #define AR_GUID_OWNER_QC                  0x0
 
 /** GUID owner is not Qualcomm. All ISVs, OEMs, and customers


### PR DESCRIPTION
Fix misformatted comment to resolve compilation error `expected ';' after top-level declarator in ar_guids.h at line 25`.