### PR TITLE
alsa endpoint: Enable multi-channel playback

### DIFF
--- a/fwk/platform/modules/generic/endpoint/alsa_device/build/CMakeLists.txt
+++ b/fwk/platform/modules/generic/endpoint/alsa_device/build/CMakeLists.txt
@@ -21,6 +21,7 @@ set(alsa_device_includes
 	${LIB_ROOT}/capi/src
 	${LIB_ROOT}/lib/inc
 	${LIB_ROOT}/lib/src/tinyalsa
+	../../../../../../spf/utils/interleaver/inc
 )
 
 spf_module_sources(


### PR DESCRIPTION
Fix the logic for multi-channel playback in the capi_alsa_device for both interleaved and non-interleaved data formats. Data will no longer be written one channel at a time and will instead be written all at once.