### PR TITLE
h2xml: Fix incorrect parameter ID label in example_gain_module_api.h

### DIFF
--- a/modules/examples/gain/api/example_gain_module_api.h
+++ b/modules/examples/gain/api/example_gain_module_api.h
@@ -71,8 +71,8 @@
 /* ID of the parameter used to set the gain */
 #define PARAM_ID_GAIN_MODULE_GAIN 0x08001175
 
-/** @h2xmlp_parameter   {"PARAM_ID_GAIN_MODULE",
-                         PARAM_ID_GAIN_MODULE}
+/** @h2xmlp_parameter   {"PARAM_ID_GAIN_MODULE_GAIN",
+                         PARAM_ID_GAIN_MODULE_GAIN}
     @h2xmlp_description {Configures the gain}
     @h2xmlp_toolPolicy  {Calibration; RTC} */
 


### PR DESCRIPTION
Replace PARAM_ID_GAIN_MODULE with PARAM_ID_GAIN_MODULE_GAIN in @h2xmlp_parameter annotations to resolve H2XML parsing errors. This ensures the expected 'INT' type is used instead of 'LABEL', aligning with h2xml tool requirements.