### PR TITLE
Kconfig: Rename channel mixer config symbol to match CMake usage

### DIFF
--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -22,8 +22,8 @@ config EXAMPLE_GAIN
         tristate "Enable EXAMPLE_GAIN Library"
         default n
 
-config CH_MIXER
-        tristate "Enable CH_MIXER Library"
+config CHMIXER
+        tristate "Enable CHMIXER Library"
         default y
 
 config MSIIR


### PR DESCRIPTION
Update the Kconfig symbol for the channel mixer module from CH_MIXER to CHMIXER to align with the configuration name used in the corresponding CMake file.