### PR TITLE
posal: Resolve build issues and enable GNU extensions

### DIFF
--- a/fwk/platform/posal/src/linux/posal_data_log.c
+++ b/fwk/platform/posal/src/linux/posal_data_log.c
@@ -491,7 +491,7 @@ static void *posal_data_alloc_log_buffer_internal(uint32_t                buf_si
     * Returns NULL if log code is disabled on the GUI
     */
 
-   log_pkt_ptr = log_alloc(log_code, log_pkt_size);
+   log_pkt_ptr = (void *)(uintptr_t) log_alloc(log_code, log_pkt_size);
    if (NULL == log_pkt_ptr)
    {
       AR_MSG(DBG_ERROR_PRIO, "posal_data_alloc(): Invalid log ptr allocation log_pkt_ptr = %p", log_pkt_ptr);

--- a/fwk/platform/posal/src/linux/posal_linux_thread.c
+++ b/fwk/platform/posal/src/linux/posal_linux_thread.c
@@ -11,6 +11,7 @@
 /* ----------------------------------------------------------------------------
  * Include Files
  * ------------------------------------------------------------------------- */
+#define _GNU_SOURCE
 #include "posal.h"
 #include "posal_thread_profiling.h"
 #include "posal_internal.h"

--- a/fwk/platform/posal/src/linux/posal_rtld.c
+++ b/fwk/platform/posal/src/linux/posal_rtld.c
@@ -11,6 +11,7 @@
 /* =======================================================================
 INCLUDE FILES FOR MODULE
 ========================================================================== */
+#define _GNU_SOURCE
 #include "posal.h"
 #include "posal_internal.h"
 #include "posal_rtld.h"

--- a/fwk/platform/posal/src/linux/posal_timer.c
+++ b/fwk/platform/posal/src/linux/posal_timer.c
@@ -149,7 +149,7 @@ int32_t posal_timer_create_v2(posal_timer_t *                        pp_timer,
 
    //Allocate timer id
    timer_t *timerId = NULL;
-   if (NULL == (timerId = (posal_timer_info_t *)posal_memory_malloc(sizeof(timer_t), heap_id)))
+   if (NULL == (timerId = (timer_t *)posal_memory_malloc(sizeof(timer_t), heap_id)))
    {
       AR_MSG(DBG_ERROR_PRIO, "Memory allocation failure");
       posal_memory_free(p_timer);


### PR DESCRIPTION
Add _GNU_SOURCE macro to enable GNU-specific APIs like pthread_setname_np and dlinfo.
Correct type mismatch by casting to timer_t* instead of posal_timer_info_t*.

These changes address build errors and warnings encountered during compilation with GCC 14.2, ensuring compatibility and cleaner builds across platforms.