### PR TITLE
armor: Add API compatibility checker configuration file

### DIFF
--- a/public_headers/config.yml
+++ b/public_headers/config.yml
@@ -1,0 +1,12 @@
+project: https://github.com/AudioReach/audioreach-engine
+
+branches:
+  master:
+    modes:
+      non-blocking:
+        headers:
+          - fwk/api/apm/*.h
+          - fwk/api/ar_utils/*.h
+          - fwk/api/modules/*.h
+          - fwk/api/vcpm/*.h
+          - fwk/spf/dls/api/*.h


### PR DESCRIPTION
Add config.yml in the public_headers directory to define backward compatibility rules for public API headers. Configure the checker in non-blocking mode until blocking mode is supported by armor.