### PR TITLE
osal: timer: Use CLOCK_MONOTONIC for Zephyr builds.

### DIFF
--- a/ar_osal/src/linux/ar_osal_timer.c
+++ b/ar_osal/src/linux/ar_osal_timer.c
@@ -14,6 +14,12 @@
 #include "ar_osal_error.h"
 #include "ar_osal_heap.h"
 
+#ifdef __ZEPHYR__
+#define CLOCK_ID CLOCK_MONOTONIC
+#else
+#define CLOCK_ID CLOCK_BOOTTIME
+#endif
+
 /**
  * \brief ar_timer_get_time_in_us
  *        Gets the wall clock time in microseconds
@@ -25,7 +31,7 @@ uint64_t ar_timer_get_time_in_us(void)
     uint64_t us = 0;
     struct timespec ts;
 
-    if (!clock_gettime(CLOCK_BOOTTIME, &ts))
+    if (!clock_gettime(CLOCK_ID, &ts))
         us = ((ts.tv_sec * 1000000LL) + (ts.tv_nsec / 1000LL));
 
     return us;
@@ -42,7 +48,7 @@ uint64_t ar_timer_get_time_in_ms(void)
     uint64_t ms = 0;
     struct timespec ts;
 
-    if(!clock_gettime(CLOCK_BOOTTIME, &ts))
+    if(!clock_gettime(CLOCK_ID, &ts))
         ms = ((ts.tv_sec * 1000LL) + (ts.tv_nsec / 1000000LL));
 
     return ms;


### PR DESCRIPTION
Replace CLOCK_BOOTTIME with CLOCK_MONOTONIC in timer functions when building for Zephyr platform to ensure compatibility with Zephyr's POSIX API implementation.

CLOCK_BOOTTIME is not defined in Zephyr's POSIX compatibility layer, causing compilation failures. CLOCK_MONOTONIC provides equivalent monotonic time functionality and is available in Zephyr's clock API.