### PR TITLE
arch: zephyr: Add Kconfig configuration file.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1,5 +1,6 @@
 rsource "hexagon/Kconfig"
 rsource "linux/Kconfig"
+rsource "zephyr/Kconfig"
 
 config PROC_DOMAIN
     string "Target Processor Domain ID for ARE modules"

--- a/arch/zephyr/Kconfig
+++ b/arch/zephyr/Kconfig
@@ -1,0 +1,6 @@
+menuconfig ARCH_ZEPHYR
+    bool "Zephyr Architecture"
+    help
+        Say yes if you need Zephyr Architecture support
+
+endif


### PR DESCRIPTION
Add Kconfig file for Zephyr architecture support to enable build-time configuration of AudioReach Engine components on Zephyr platform. Update arch/Kconfig to include the new Zephyr configuration file.