### PR TITLE
zephyr: Add west.yml manifest for AudioReach Engine application.

### DIFF
--- a/zephyr/west.yml
+++ b/zephyr/west.yml
@@ -1,0 +1,29 @@
+# West manifest for AudioReach Engine Zephyr application
+manifest:
+  version: "0.13"
+
+  defaults:
+    remote: upstream
+    revision: main
+
+  remotes:
+    - name: upstream
+      url-base: https://github.com/zephyrproject-rtos
+
+  projects:
+    # Zephyr RTOS - pinned to specific revision
+    - name: zephyr
+      remote: upstream
+      revision: 5eecc55398708d6944046a0379343fea1279c831
+      path: zephyr
+      west-commands: scripts/west-commands.yml
+      import:
+        name-allowlist:
+          - hal_xtensa
+          - hal_nxp
+          - libmetal
+          - open-amp
+
+  self:
+    # This repository contains the AudioReach Engine application
+    path: audioreach-engine


### PR DESCRIPTION
Add west.yml configuration file to define the Zephyr workspace manifest for the AudioReach Engine application.