### PR TITLE
posal: linux: Implement oneshot absolute timer start and delete APIs

### DIFF
--- a/fwk/platform/posal/src/linux/posal_linux_stubs.c
+++ b/fwk/platform/posal/src/linux/posal_linux_stubs.c
@@ -51,10 +51,6 @@ mid_stack_pair_info_t *get_platform_prop_info(platform_prop_t prop, uint32_t *el
    return NULL;
 }
 
-int32 posal_timer_oneshot_start_absolute(posal_timer_t pTimer, int64_t time){
-   return AR_EOK;
-}
-
 ar_result_t posal_power_mgr_send_command(uint32_t msg_opcode, void *payload_ptr , uint32_t payload_size){
    return AR_EOK;
 }

--- a/fwk/platform/posal/src/linux/posal_timer.c
+++ b/fwk/platform/posal/src/linux/posal_timer.c
@@ -52,7 +52,26 @@ ar_result_t posal_timer_destroy(posal_timer_t *pp_obj)
 ar_result_t posal_timer_destroy_v2(posal_timer_t *pp_obj)
 {
    posal_timer_info_t *p_timer = NULL;
-   int                 nStatus = 0;
+   int nStatus = AR_EOK;
+
+   if (!pp_obj || !*pp_obj)
+      return AR_EBADPARAM;
+
+   p_timer = (posal_timer_info_t *)(*pp_obj);
+   if (!p_timer->timer_obj)
+      return AR_EBADPARAM;
+
+   timer_t *timerId = (timer_t *)p_timer->timer_obj;
+
+   nStatus = timer_delete(*timerId);
+   if (nStatus != 0) {
+      AR_MSG(DBG_ERROR_PRIO, "Failed to destroy timer");
+      return AR_EFAILED;
+   }
+
+   free(timerId);
+   free(p_timer);
+   *pp_obj = NULL;
 
    return AR_EOK;
 }
@@ -293,6 +312,46 @@ uint64_t posal_timer_get_time_in_msec(void)
  */
 int32_t posal_timer_oneshot_start_duration(posal_timer_t p_obj, int64_t duration)
 {
+   return AR_EOK;
+}
+
+/**
+  Starts the oneshot absolute timer.
+
+  @datatypes
+  posal_timer_t
+
+  @param[in] pTimer    Pointer to the POSAL timer object.
+  @param[in] duration  Duration of the timer, in microseconds.
+
+  @return
+  An indication of success (0) or failure (nonzero).
+
+  @dependencies
+  The timer must be created using posal_timer_create().
+ */
+int32_t posal_timer_oneshot_start_absolute(posal_timer_t p_obj, int64_t time)
+{
+   int nStatus = AR_EOK;
+   posal_timer_info_t *p_timer = (posal_timer_info_t *)p_obj;
+   timer_t *timer = (timer_t*) p_timer->timer_obj;
+   struct itimerspec its = {0};
+
+   // Set the timer delay and interval
+   its.it_interval.tv_sec = 0;
+   its.it_interval.tv_nsec = 0;
+
+   //Indicates when the timer will fire next
+   its.it_value.tv_sec = time / 1000000;
+   its.it_value.tv_nsec = (time % 1000000) * 1000;
+
+   nStatus = timer_settime(*timer, TIMER_ABSTIME, &its, NULL);
+   if (nStatus != 0)
+   {
+      AR_MSG(DBG_ERROR_PRIO, "Failed to start oneshot absolute timer for time: %lld", time);
+      return AR_EFAILED;
+   }
+
    return AR_EOK;
 }
 


### PR DESCRIPTION
Add implementation for posal_timer_oneshot_start_absolute() to start timers with absolute time values and enhance posal_timer_destroy_v2() to properly clean up timer resources.