### PR TITLE
posal: Add Zephyr architecture support.

### DIFF
--- a/fwk/platform/posal/build/CMakeLists.txt
+++ b/fwk/platform/posal/build/CMakeLists.txt
@@ -61,6 +61,12 @@ if(ARSPF_WIN_PORTING) #platform windows
       #${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_timer_timerqueue.c
       #${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_timer_waitable_timers.c
    )
+elseif(CONFIG_ARCH_ZEPHYR)
+   list (APPEND lib_srcs_list
+      ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_condvar.c
+      ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_timer.c
+      #posal_rtld is not supported in zephyr.
+   )
 else() # for QNX & LRH
    list (APPEND lib_srcs_list
       ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_condvar.c
@@ -90,6 +96,10 @@ endif()
 if(ARSPF_WIN_PORTING)
    set (lib_link_libs_list
       winmm.lib
+   )
+elseif(CONFIG_ARCH_ZEPHYR)
+   set (lib_link_libs_list
+      zephyr_interface
    )
 else()
    set (lib_link_libs_list


### PR DESCRIPTION
Add conditional compilation support for CONFIG_ARCH_ZEPHYR in the POSAL build system. Include posal_condvar.c and posal_timer.c for Zephyr builds while excluding posal_rtld compilation as it is not supported on Zephyr.

Link against the zephyr_interface library when building for Zephyr architecture to provide necessary platform abstractions.