### PR TITLE
Add pre-merge workflow for RPI builds

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -1,0 +1,141 @@
+---
+name: pre_merge_build
+run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre Merge Build:' }}${{ github.event.pull_request.number || github.run_number }}
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  load_parameters:
+    uses: Audioreach/audioreach-workflows/.github/workflows/loading.yml@master
+    with:
+      event_name: ${{ github.event_name }}
+      pr_ref: ${{ github.event.pull_request.head.ref }}
+      pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
+
+  build:
+    needs: load_parameters
+    uses: Audioreach/audioreach-workflows/.github/workflows/build.yml@master
+    secrets: inherit
+    with:
+      build_args: ${{ needs.load_parameters.outputs.build_args }}
+      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
+      event_name: ${{ github.event_name }}
+      pr_ref: ${{ github.event.pull_request.head.ref }}
+      pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
+
+  process_image:
+    needs: [ load_parameters, build ]
+    uses: Audioreach/audioreach-workflows/.github/workflows/process_image.yml@master
+    secrets: inherit
+    with:
+      event_name: ${{ github.event_name }}
+      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
+      pr_ref: ${{ github.event.pull_request.head.ref }}
+      pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
+
+  filter_test_matrix:
+    needs: load_parameters
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.filter.outputs.test_matrix }}
+      has_tests: ${{ steps.filter.outputs.has_tests }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+            MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+
+            echo "RAW build_matrix:"
+            echo "$MATRIX"
+
+            echo "Validating JSON..."
+            echo "$MATRIX" | jq . >/dev/null
+
+            # Supports:
+            # 1) object keyed by name: { "name": {testing_enabled:true}, ... }
+            # 2) array of entries: [ {Testing_enabled:true,...}, ... ]  (will convert to include list)
+            FILTERED=$(
+              echo "$MATRIX" | jq -c '
+                if type == "object" then
+                  to_entries
+                  | map(select(.value.testing_enabled == true))
+                  | from_entries
+                elif type == "array" then
+                  map(select(.testing_enabled == true))  # <-- Just return the array
+                else
+                  error("Unsupported build_matrix JSON type: " + (type|tostring))
+                end
+              '
+            )
+
+            echo "Filtered matrix (pretty):"
+            echo "$FILTERED" | jq .
+
+            # Determine if there are any tests to run
+            HAS_TESTS="false"
+            if [ "$FILTERED" != "[]" ] && [ "$FILTERED" != "{}" ] && [ "$FILTERED" != "null" ] && [ -n "$FILTERED" ]; then
+              # Additional check: for objects, ensure they have at least one key
+              if echo "$FILTERED" | jq -e 'if type == "object" then . | length > 0 elif type == "array" then . | length > 0 else false end' >/dev/null 2>&1; then
+                HAS_TESTS="true"
+              fi
+            fi
+
+            echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
+            echo "has_tests=$HAS_TESTS" >> "$GITHUB_OUTPUT"
+            echo "Tests enabled: $HAS_TESTS"
+
+  trigger_lava:
+    needs: [process_image, filter_test_matrix]
+    if: needs.filter_test_matrix.outputs.has_tests == 'true'
+    permissions:
+      checks: write
+      pull-requests: write
+    uses: AudioReach/audioreach-workflows/.github/workflows/test.yml@master
+    secrets: inherit
+    with:
+      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}
+
+  # This job ensures the workflow always completes successfully
+  # even when trigger_lava is skipped due to no tests
+  workflow_complete:
+    needs: [load_parameters, build, process_image, filter_test_matrix, trigger_lava]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Workflow completion status
+        run: |
+          echo "=== Workflow Completion Summary ==="
+          echo "load_parameters: ${{ needs.load_parameters.result }}"
+          echo "build: ${{ needs.build.result }}"
+          echo "process_image: ${{ needs.process_image.result }}"
+          echo "filter_test_matrix: ${{ needs.filter_test_matrix.result }}"
+          echo "trigger_lava: ${{ needs.trigger_lava.result }}"
+          echo ""
+          
+          if [ "${{ needs.filter_test_matrix.outputs.has_tests }}" == "false" ]; then
+            echo "ℹ️  No tests were enabled in the build matrix - trigger_lava was skipped"
+          fi
+          
+          # Check if any required job failed
+          if [ "${{ needs.load_parameters.result }}" == "failure" ] || \
+             [ "${{ needs.build.result }}" == "failure" ] || \
+             [ "${{ needs.process_image.result }}" == "failure" ] || \
+             [ "${{ needs.filter_test_matrix.result }}" == "failure" ]; then
+            echo "❌ Workflow failed - one or more required jobs failed"
+            exit 1
+          fi
+          
+          # trigger_lava can be skipped or success, both are acceptable
+          if [ "${{ needs.trigger_lava.result }}" == "failure" ]; then
+            echo "❌ Testing failed"
+            exit 1
+          fi
+          
+          echo "✅ Workflow completed successfully"

--- a/ci/files_to_copy.sh
+++ b/ci/files_to_copy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+
+# Move outside the github workspace to avoid conflicts
+cd ..
+
+# copy the build artifacts to a temporary directory
+cp -R build/usr/* /tmp/rootfs/usr/

--- a/ci/rpi_build.sh
+++ b/ci/rpi_build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+set -ex
+# Source SDK environment 
+source ${GITHUB_WORKSPACE}/install/environment-setup-cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi
+
+# Make sure we are in the right directory
+cd ${GITHUB_WORKSPACE}
+# Create and enter build directory
+mkdir -p build && cd build
+
+# Configure with CMake
+cmake \
+    -DARCH=linux \
+    -DCONFIG=defconfig \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_TOOLCHAIN_FILE=${OECORE_NATIVE_SYSROOT}/usr/share/cmake/OEToolchainConfig.cmake \
+    -G "Unix Makefiles" \
+    ..
+
+# Build and install
+make -j$(nproc)
+make DESTDIR=${GITHUB_WORKSPACE}/build install


### PR DESCRIPTION
Add a pre-merge GitHub Actions workflow to run
Raspberry Pi (RPI) target builds.

Add RPI build scripts and configuration under ci/
and use them from the pre-merge workflow to trigger
a centralized RPI build process. [1]

Pass CMake build arguments directly in
rpi_build.sh to ensure correct quoting during
Docker invocation and to avoid errors such as:
"invalid reference format: repository name
(library/Makefiles) must be lowercase".

Add rpi_build_options.txt as an intentionally
empty placeholder to allow future optional RPI
build arguments without modifying the script.

[1] https://github.com/AudioReach/audioreach-workflows/pull/70