### PR TITLE
Kconfig: move COMPILE_POSAL from arch Kconfigs to posal Kconfig

### DIFF
--- a/arch/hexagon/Kconfig
+++ b/arch/hexagon/Kconfig
@@ -22,13 +22,4 @@ config DISABLE_PLATFORM
 	Select y to disable platform compilation,
 	say n to compile platform.
 
-config COMPILE_POSAL
-	bool "Compile POSAL source files."
-	default n
-	help
-	Select y to compile posal source files,
-	say n to skip posal source files compilation.
-
 endif
-
-

--- a/arch/linux/Kconfig
+++ b/arch/linux/Kconfig
@@ -12,11 +12,4 @@ config DISABLE_PLATFORM
         Select y to disable platform compilation,
         say n to compile platform.
 
-config COMPILE_POSAL
-    bool "Compile POSAL source files."
-    default y
-    help
-        Select y to compile posal source files,
-        say n to skip posal source files compilation.
-
 endif

--- a/fwk/platform/posal/Kconfig
+++ b/fwk/platform/posal/Kconfig
@@ -1,5 +1,13 @@
 menu "POSAL"
 
+config COMPILE_POSAL
+        bool "Compile POSAL source files."
+        default n if ARCH_HEXAGON
+        default y
+        help
+           Select y to compile posal source files,
+           say n to skip posal source files compilation.
+
 config DLS_DATA_LOGGING
         bool "Enable Data Logging using Data Logging Service (DLS)."
         default y


### PR DESCRIPTION
COMPILE_POSAL was identically duplicated across arch Kconfigs (hexagon & linux), with only the default value differing per arch.

Consolidate the symbol into fwk/platform/posal/Kconfig as a single definition, using arch-conditioned default lines to preserve the existing per-arch behaviour:

  - default n if ARCH_HEXAGON  (platform supplies posal externally)
  - default y                  (fallback for Linux, and any future
                                arch that builds posal from source)

Remove the now-redundant COMPILE_POSAL blocks from:
  - arch/hexagon/Kconfig
  - arch/linux/Kconfig