### PR TITLE
CMake: update defconfig file handling for Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,14 @@ if (NOT CONFIG)
    set (CONFIG "defconfig")
 endif()
 
-message(STATUS "using ${PROJECT_SOURCE_DIR}/arch/${ARCH}/configs/${CONFIG} config")
-configure_file("${PROJECT_SOURCE_DIR}/arch/${ARCH}/configs/${CONFIG}" ${SPF_DOT_CONFIG_PATH} COPYONLY)
+if (ARCH MATCHES "^(zephyr)")
+   set(SPF_CONFIG_PATH "${PROJECT_SOURCE_DIR}/app/${CONFIG}")
+else()
+   set(SPF_CONFIG_PATH "${PROJECT_SOURCE_DIR}/arch/${ARCH}/configs/${CONFIG}")
+endif()
+
+message(STATUS "using ${SPF_CONFIG_PATH} config")
+configure_file("${SPF_CONFIG_PATH}" ${SPF_DOT_CONFIG_PATH} COPYONLY)
 
 include(scripts/cmake/spf.cmake)
 include(scripts/cmake/spf_build.cmake)


### PR DESCRIPTION
Zephyr applications store their SPF config under app/ rather than arch/${ARCH}/configs/. Introduce SPF_CONFIG_PATH to select the correct location per arch, preventing configure_file() from failing on a missing path for Zephyr builds.