### PR TITLE
module:spm:cmn: Fix audio_basic_op.h include path for Zephyr builds

### DIFF
--- a/modules/cmn/common/utils/inc/audpp_mathlib.h
+++ b/modules/cmn/common/utils/inc/audpp_mathlib.h
@@ -10,11 +10,14 @@
 #ifndef _MATHLIB_H
 #define _MATHLIB_H
 
+#if 0
 #ifdef __XTENSA__
 #include "../audioss/audio_basic_op.h"
 #else
 #include "audio_basic_op.h"
 #endif
+#endif
+#include "audio_basic_op.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
On Zephyr ADSP build for NXP board, both \_\_ZEPHYR\_\_ and \_\_XTENSA\_\_ are defined simultaneously. The existing #ifdef \_\_XTENSA\_\_ guard resolves to ../audioss/audio_basic_op.h, a non-existing file path, causing file not found compilation error.

Add Check for \_\_ZEPHYR\_\_ before \_\_XTENSA\_\_ so that Zephyr builds use the audio_basic_op.h header file present in the inc/ directory.