### PR TITLE
posal: Fix clock source and tv_sec truncation in periodic timer

### DIFF
--- a/fwk/platform/posal/src/linux/posal_timer.c
+++ b/fwk/platform/posal/src/linux/posal_timer.c
@@ -22,6 +22,12 @@ INCLUDE FILES FOR MODULE
 /*--------------------------------------------------------------*/
 /* Macro / Global definitions                                            */
 /* -------------------------------------------------------------*/
+#ifdef __ZEPHYR__
+#define POSAL_CLOCK_ID CLOCK_MONOTONIC
+#else
+#define POSAL_CLOCK_ID CLOCK_BOOTTIME
+#endif
+
 #define ATS_TIMER_MAX_DURATION 0
 #define TIMER_SIGNAL_MARGIN 300
 #define TIMER_SLEEP_MARGIN 200
@@ -203,7 +209,7 @@ int32_t posal_timer_create_v2(posal_timer_t *                        pp_timer,
    timer_event.sigev_notify_function = &posal_timer_expire_cb;
    timer_event.sigev_value.sival_ptr = p_timer; //Save the timer info for callback function
 
-   nStatus = timer_create(CLOCK_REALTIME, &timer_event, timerId);
+   nStatus = timer_create(POSAL_CLOCK_ID, &timer_event, timerId);
    if (nStatus != 0)
    {
       AR_MSG(DBG_ERROR_PRIO, "Failed to create timer");

--- a/fwk/platform/posal/src/linux/posal_timer.c
+++ b/fwk/platform/posal/src/linux/posal_timer.c
@@ -384,10 +384,10 @@ int32_t posal_timer_periodic_start(posal_timer_t p_obj, int64_t duration)
    struct itimerspec its = {0};
 
    //Set the timer delay and interval
-   its.it_interval.tv_sec = 0;
-   its.it_interval.tv_nsec = duration * 1000; //Convert duration to nanoseconds
-   its.it_value.tv_sec = 0;
-   its.it_value.tv_nsec = duration * 1000; //Indicates when the timer will fire next
+   its.it_interval.tv_sec  = duration / 1000000;
+   its.it_interval.tv_nsec = (duration % 1000000) * 1000;
+   its.it_value.tv_sec     = its.it_interval.tv_sec;
+   its.it_value.tv_nsec    = its.it_interval.tv_nsec;
 
    //Start the timer
    nStatus = timer_settime(*timer, 0, &its, NULL);


### PR DESCRIPTION
* posal: Fix tv_sec truncation in periodic timer timespec conversion
* posal: Use CLOCK_MONOTONIC/CLOCK_BOOTTIME instead of CLOCK_REALTIME