### PR TITLE
posal: Work around missing TIMER_ABSTIME support on Zephyr

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -1,0 +1,26 @@
+# West patch manifest for AudioReach Engine Zephyr application
+# Apply with: west patch apply
+# Clean with: west patch clean
+
+patches:
+  - path: 0001-posal-workaround-TIMER_ABSTIME-on-zephyr.patch
+    sha256sum: 20cc926e4eb3c427ace1232ce61ca42362b5cdff75ff764c6dcd43db7ab5aeb7
+    module: audioreach-engine
+    author: Aditya Rathi
+    email: aditrath@qti.qualcomm.com
+    date: 2026-05-29
+    upstreamable: false
+    apply-command: git apply
+    comments: |
+      Work around missing TIMER_ABSTIME support in Zephyr POSIX timer_settime().
+
+      Zephyr's POSIX layer does not correctly implement TIMER_ABSTIME, causing
+      the oneshot absolute timer to not fire as expected. Under __ZEPHYR__,
+      convert the absolute expiry time to a relative duration by subtracting
+      the current time via posal_timer_get_time(), clamp to zero if the deadline
+      has already passed, and arm the timer without TIMER_ABSTIME.
+
+      Applies to: fwk/platform/posal/src/linux/posal_timer.c
+
+checkout-command: git checkout .
+clean-command: git clean -d -f -x

--- a/zephyr/patches/0001-posal-workaround-TIMER_ABSTIME-on-zephyr.patch
+++ b/zephyr/patches/0001-posal-workaround-TIMER_ABSTIME-on-zephyr.patch
@@ -1,0 +1,51 @@
+From fe8edee366fc5ad4cb362790df5e1d4dee5e32bb Mon Sep 17 00:00:00 2001
+From: Aditya Rathi <aditrath@qti.qualcomm.com>
+Date: Mon, 18 May 2026 16:22:24 +0530
+Subject: [PATCH] posal: Work around missing TIMER_ABSTIME support on Zephyr
+
+Zephyr's POSIX layer does not correctly implement TIMER_ABSTIME in
+timer_settime(). Passing it causes the oneshot absolute timer to
+not fire as expected.
+
+Under __ZEPHYR__, convert the absolute expiry time to a relative
+duration by subtracting the current time via ar_timer_get_time_in_us(),
+clamping to zero if the deadline has already passed, and arming the
+timer without TIMER_ABSTIME. The generic Linux path is unchanged.
+
+Signed-off-by: Aditya Rathi <aditrath@qti.qualcomm.com>
+---
+ fwk/platform/posal/src/linux/posal_timer.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/fwk/platform/posal/src/linux/posal_timer.c b/fwk/platform/posal/src/linux/posal_timer.c
+index 3bc835edc..d21fc1abb 100644
+--- a/fwk/platform/posal/src/linux/posal_timer.c
++++ b/fwk/platform/posal/src/linux/posal_timer.c
+@@ -341,11 +341,24 @@ int32_t posal_timer_oneshot_start_absolute(posal_timer_t p_obj, int64_t time)
+    its.it_interval.tv_sec = 0;
+    its.it_interval.tv_nsec = 0;
+ 
++#ifdef __ZEPHYR__
++   // Zephyr POSIX does not implement TIMER_ABSTIME correctly in timer_settime().
++   // Convert the absolute expiry time to a relative duration by subtracting
++   // the current time, then arm the timer without TIMER_ABSTIME.
++   int64_t duration_us = time - (int64_t)posal_timer_get_time();
++   if (duration_us < 0)
++      duration_us = 0;
++   its.it_value.tv_sec = duration_us / 1000000;
++   its.it_value.tv_nsec = (duration_us % 1000000) * 1000;
++
++   nStatus = timer_settime(*timer, 0, &its, NULL);
++#else
+    //Indicates when the timer will fire next
+    its.it_value.tv_sec = time / 1000000;
+    its.it_value.tv_nsec = (time % 1000000) * 1000;
+ 
+    nStatus = timer_settime(*timer, TIMER_ABSTIME, &its, NULL);
++#endif
+    if (nStatus != 0)
+    {
+       AR_MSG(DBG_ERROR_PRIO, "Failed to start oneshot absolute timer for time: %lld", time);
+-- 
+2.44.3
+


### PR DESCRIPTION
zephyr: Add west patch for TIMER_ABSTIME workaround in posal_timer
Zephyr's POSIX layer does not correctly implement TIMER_ABSTIME in
timer_settime(). Rather than mainlining a __ZEPHYR__ guard into the
source, deliver the fix as a west patch applied at build time.

Add patches.yml and the corresponding patch file under zephyr/patches/.