### PR TITLE
Fix Hexagon build errors in iir_tdf2 and audio_filter

### DIFF
--- a/modules/cmn/common/utils/inc/audio_iir_tdf2_asm.h
+++ b/modules/cmn/common/utils/inc/audio_iir_tdf2_asm.h
@@ -1,0 +1,19 @@
+/*========================================================================*/
+/**
+@file audio_iir_tdf2_asm.h
+
+This file defines flags to use Q6 ASM of IIR TDF2 functions.
+*/
+
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _AUDIO_IIRTDF2_ASM_H_
+#define _AUDIO_IIRTDF2_ASM_H_
+
+#define    QDSP6_ASM_IIRTDF2_32
+#define    QDSP6_ASM_IIRTDF2_16
+
+#endif  /* _AUDIO_IIRTDF2_ASM_H_ */

--- a/modules/cmn/common/utils/src/audio_filter.cpp
+++ b/modules/cmn/common/utils/src/audio_filter.cpp
@@ -450,7 +450,7 @@ void biquad_process_io
 )
 {
     
-/*#if ((defined __hexagon__) || (defined __qdsp6__))
+#if ((defined __hexagon__) || (defined __qdsp6__))
     
     int16 *bufPtr = srcBuf;
     int16 *coeffptr = &filter->coeffsL16Q13[filter->coeffIndex];
@@ -459,7 +459,7 @@ void biquad_process_io
 
 
 
-#else  */  
+#else
     int32 i;
     int16 xInL16;
     int16 *yL16 = filter->yL16;
@@ -520,7 +520,7 @@ void biquad_process_io
     }
     /*-- store accumulator value back --*/
     filter->yL32 = s32_extract_s40_l(yL40);
-//#endif
+#endif
 }  /*----------------- end of function biquad_process_io --------------------*/
 
 


### PR DESCRIPTION
Fix Hexagon build errors in iir_tdf2 and audio_filter
  Two build failures observed when compiling for Hexagon targets:

  1. iir_tdf2.c includes audio_iir_tdf2_asm.h under __hexagon__
     guard but the header was absent from the repository:

       iir_tdf2.c:14:10:
         fatal error: 'audio_iir_tdf2_asm.h' file not found

  2. biquad_process_io() in audio_filter.cpp accesses yL16 and
     xL16 members absent from the Hexagon _biquadFilter variant:

       audio_filter.cpp:465:27:
         error: no member named 'yL16' in '_biquadFilter'
       audio_filter.cpp:466:27:
         error: no member named 'xL16' in '_biquadFilter'

  Add audio_iir_tdf2_asm.h to modules/cmn/common/utils/inc/ and
  fix the missing Hexagon guard in biquad_process_io().
