### PR TITLE
Use pull_request trigger and remove LAVA workflow job

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -4,7 +4,7 @@ run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre 
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - master
@@ -91,21 +91,11 @@ jobs:
             echo "has_tests=$HAS_TESTS" >> "$GITHUB_OUTPUT"
             echo "Tests enabled: $HAS_TESTS"
 
-  trigger_lava:
-    needs: [process_image, filter_test_matrix]
-    if: needs.filter_test_matrix.outputs.has_tests == 'true'
-    permissions:
-      checks: write
-      pull-requests: write
-    uses: AudioReach/audioreach-workflows/.github/workflows/test.yml@master
-    secrets: inherit
-    with:
-      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}
 
   # This job ensures the workflow always completes successfully
   # even when trigger_lava is skipped due to no tests
   workflow_complete:
-    needs: [load_parameters, build, process_image, filter_test_matrix, trigger_lava]
+    needs: [load_parameters, build, process_image, filter_test_matrix]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +106,6 @@ jobs:
           echo "build: ${{ needs.build.result }}"
           echo "process_image: ${{ needs.process_image.result }}"
           echo "filter_test_matrix: ${{ needs.filter_test_matrix.result }}"
-          echo "trigger_lava: ${{ needs.trigger_lava.result }}"
           echo ""
           
           if [ "${{ needs.filter_test_matrix.outputs.has_tests }}" == "false" ]; then
@@ -129,12 +118,6 @@ jobs:
              [ "${{ needs.process_image.result }}" == "failure" ] || \
              [ "${{ needs.filter_test_matrix.result }}" == "failure" ]; then
             echo "❌ Workflow failed - one or more required jobs failed"
-            exit 1
-          fi
-          
-          # trigger_lava can be skipped or success, both are acceptable
-          if [ "${{ needs.trigger_lava.result }}" == "failure" ]; then
-            echo "❌ Testing failed"
             exit 1
           fi
           


### PR DESCRIPTION
Switch workflow trigger from pull_request_target to pull_request for safer execution in PR context. [1]

Remove the trigger_lava job and its dependencies to simplify the workflow and eliminate external test runs.

Update workflow_complete job to reflect the reduced job graph and drop checks tied to the removed job.

[1] AudioReach/audioreach-workflows#73