### PR TITLE
module: example gain: Check for data interleaving when num channel != 1

### DIFF
--- a/modules/examples/gain/capi/src/capi_example_gain_module_utils.c
+++ b/modules/examples/gain/capi/src/capi_example_gain_module_utils.c
@@ -421,7 +421,7 @@ capi_err_t capi_example_gain_module_process_set_properties(capi_example_gain_mod
                }
 
                /* Validate interleaving*/
-               if (media_fmt_ptr->format.data_interleaving != CAPI_DEINTERLEAVED_UNPACKED)
+               if (media_fmt_ptr->format.num_channels != 1 && media_fmt_ptr->format.data_interleaving != CAPI_DEINTERLEAVED_UNPACKED)
                {
                   AR_MSG(DBG_ERROR_PRIO, "capi_example_gain_module : Interleaved data not supported.");
                   return CAPI_EBADPARAM;


### PR DESCRIPTION
Example gain module runs in bypass mode when number of channel is 1 and data type received is not CAPI_DEINTERLEAVED_UNPACKED. Update condition to check for data interleaving when num channel is not 1.

CRs-Fixed: 4635334