### PR TITLE
Enable rd_sh_mem_ep deconfig control

### DIFF
--- a/fwk/spf/containers/gen_cntr/ext/rd_sh_mem_ep/build/CMakeLists.txt
+++ b/fwk/spf/containers/gen_cntr/ext/rd_sh_mem_ep/build/CMakeLists.txt
@@ -10,26 +10,30 @@
 ]]
 cmake_minimum_required(VERSION 3.10)
 
-#Include directories
-set (lib_incs_list
-     ${LIB_ROOT}/inc
-    )
+set(rd_sh_mem_ep_sources
+    ${LIB_ROOT}/src/gen_cntr_rd_sh_mem_ep.c
+)
 
-#Add the source files
-set (lib_srcs_list
-     ${LIB_ROOT}/src/gen_cntr_rd_sh_mem_ep.c
-    )
+get_property(dir_includes DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
 
-#Add the compiler flags
-set (lib_flgs_list
-     -Wno-address-of-packed-member
-    )
+set(rd_sh_mem_ep_includes
+    ${LIB_ROOT}/inc
+    ${dir_includes}
+)
 
-#Call spf_build_static_library to generate the static library
-spf_build_static_library(gen_cntr_rd_sh_mem_ep
-                         "${lib_incs_list}"
-                         "${lib_srcs_list}"
-                         "${lib_defs_list}"
-                         "${lib_flgs_list}"
-                         "${lib_link_libs_list}"
-                        )
+spf_module_sources(
+    KCONFIG     CONFIG_RD_SH_MEM_EP
+    NAME        rd_sh_mem_ep
+    MAJOR_VER   1
+    MINOR_VER   0
+    AMDB_ITYPE  "capi"
+    AMDB_MTYPE  "framework"
+    AMDB_MID    "0x07001001"
+    AMDB_TAG    "framework"
+    AMDB_MOD_NAME   "MODULE_ID_RD_SHARED_MEM_EP"
+    SRCS        ${rd_sh_mem_ep_sources}
+    INCLUDES    ${rd_sh_mem_ep_includes}
+    H2XML_HEADERS    "${PROJECT_SOURCE_DIR}/fwk/api/modules/rd_sh_mem_ep_api.h"
+    QACT_MODULE_TYPE    "generic"
+    CFLAGS      "-Wno-address-of-packed-member"
+)


### PR DESCRIPTION
The original implementation builds rd_sh_mem_ep as a static library, which prevents it from being controlled via deconfig. Convert the build definition to spf_module_sources so the module can be enabled/disabled through CONFIG_RD_SH_MEM_EP.