### PR TITLE
posal: linux: Add posal_time.c with UTC time API stubs

### DIFF
--- a/fwk/platform/posal/build/CMakeLists.txt
+++ b/fwk/platform/posal/build/CMakeLists.txt
@@ -65,6 +65,7 @@ elseif(CONFIG_ARCH_ZEPHYR)
    list (APPEND lib_srcs_list
       ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_condvar.c
       ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_timer.c
+      ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_time.c
       #posal_rtld is not supported in zephyr.
    )
 else() # for QNX & LRH
@@ -72,6 +73,7 @@ else() # for QNX & LRH
       ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_condvar.c
       ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_timer.c
       ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_rtld.c
+      ${LIB_ROOT}/src/${TGT_SPECIFIC_FOLDER}/posal_time.c
    )
 endif()
 

--- a/fwk/platform/posal/src/linux/posal_time.c
+++ b/fwk/platform/posal/src/linux/posal_time.c
@@ -1,0 +1,43 @@
+/**
+ * \file posal_time.c
+ * \brief
+ *  This file contains stub implementations of the UTC time APIs for Linux targets.
+ *
+ * \copyright
+ *  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* ----------------------------------------------------------------------------
+ * Include Files
+ * ------------------------------------------------------------------------- */
+#include "posal_time.h"
+#include "ar_error_codes.h"
+
+/* ----------------------------------------------------------------------------
+ * Function Definitions
+ * ------------------------------------------------------------------------- */
+
+uint32_t posal_get_time_module_size()
+{
+   return 0;
+}
+
+int32_t posal_reset_utc_time_module(void *utc_time_module_ptr)
+{
+   return AR_EUNSUPPORTED;
+}
+
+int32_t posal_query_utc_time_from_nw(void *utc_time_module_ptr, uint32_t time_unit)
+{
+   return AR_EUNSUPPORTED;
+}
+
+int32_t posal_date_time_get_utc_time(void *utc_time_module_ptr,
+                                     posal_time qtime,
+                                     uint32_t requested_time_unit,
+                                     uint32_t *utc_time_msw,
+                                     uint32_t *utc_time_lsw)
+{
+   return AR_EUNSUPPORTED;
+}


### PR DESCRIPTION
Commit 0b7d88447 introduced posal_time.h declaring four UTC time APIs but shipped no Linux implementation, causing a runtime symbol lookup error when loading libspf.so on Linux targets.

Add posal_time.c under fwk/platform/posal/src/linux/ with stub implementations to avoid undefined symbols at run time.
