### PR TITLE
build: Add posal_time.c to posal Android build

### DIFF
--- a/fwk/platform/posal/build/Android.mk
+++ b/fwk/platform/posal/build/Android.mk
@@ -59,6 +59,7 @@ LOCAL_SRC_FILES := \
     src/linux/posal_power_mgr.c \
     src/linux/posal_rtld.c \
     src/linux/posal_thread_attr_cfg.c \
+    src/linux/posal_time.c \
     src/linux/posal_timer.c \
     src/linux/private/posal_private.c
 


### PR DESCRIPTION
Add posal_time.c to source file list in posal Android.mk file to compile it into posal library, matching the existing CMake build wiring.